### PR TITLE
Feat: extend CALLDATA instructions

### DIFF
--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -16,6 +16,8 @@ jobs:
     - uses: actions/checkout@v4
 #    - uses: swift-actions/setup-swift@v2
     - uses: SwiftyLab/setup-swift@latest
+      with:
+        swift-version: '6.0'
     
     - name: Build
       run: swift build

--- a/Sources/Interpreter/Instructions/System.swift
+++ b/Sources/Interpreter/Instructions/System.swift
@@ -60,8 +60,6 @@ enum SystemInstructions {
         let newValue = UInt64(m.data.count)
         m.stackPush(value: U256(from: newValue))
     }
-<<<<<<< Updated upstream
-=======
 
     static func callDataCopy(machine m: inout Machine) {
         // Pop the required values from the stack: memory offset, code offset, and size.
@@ -101,5 +99,27 @@ enum SystemInstructions {
             m.machineStatus = Machine.MachineStatus.Exit(err)
         }
     }
->>>>>>> Stashed changes
+
+    static func callDataLoad(machine m: inout Machine) {
+        if !m.gasRecordCost(cost: GasConstant.VERYLOW) {
+            return
+        }
+
+        guard let index = m.stackPop() else {
+            return
+        }
+
+        var load = [UInt8](repeating: 0, count: 32)
+        let dataCount = UInt(m.data.count)
+        if let uintIndex = index.getUInt, uintIndex < dataCount {
+            let countToCopy = Int(min(32, dataCount - uintIndex))
+            let intIndex = Int(uintIndex)
+
+            let sourceRange = intIndex ..< (intIndex + countToCopy)
+            let destinationRange = 0 ..< countToCopy
+            load.replaceSubrange(destinationRange, with: m.data[sourceRange])
+        }
+        let newValue = U256.fromBigEndian(from: load)
+        m.stackPush(value: newValue)
+    }
 }

--- a/Sources/Interpreter/Instructions/System.swift
+++ b/Sources/Interpreter/Instructions/System.swift
@@ -60,4 +60,46 @@ enum SystemInstructions {
         let newValue = UInt64(m.data.count)
         m.stackPush(value: U256(from: newValue))
     }
+<<<<<<< Updated upstream
+=======
+
+    static func callDataCopy(machine m: inout Machine) {
+        // Pop the required values from the stack: memory offset, code offset, and size.
+        guard let rawMemoryOffset = m.stackPop(),
+              let rawDataOffset = m.stackPop(),
+              let rawSize = m.stackPop()
+        else {
+            return
+        }
+
+        // This situation possible only for 32-bit context (for example wasm32)
+        guard let size = rawSize.getUInt else { m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas)); return }
+
+        // Calculate the gas cost for the very low copy operation.
+        let cost = GasCost.veryLowCopy(size: size)
+
+        // Record the gas cost for the copy operation.
+        if !m.gasRecordCost(cost: cost) {
+            return
+        }
+
+        // If the size is zero, no copying is required.
+        if size == 0 {
+            return
+        }
+
+        // This situation possible only for 32-bit context (for example wasm32)
+        guard let memoryOffset = rawMemoryOffset.getUInt else { m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas)); return }
+        guard let dataOffset = rawDataOffset.getUInt else { m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas)); return }
+
+        guard m.resizeMemoryAndRecordGas(offset: memoryOffset, size: size) else {
+            return
+        }
+
+        // Perform the call-data copy. If the copy fails, update the machine status with the error.
+        if case .failure(let err) = m.memory.copyData(memoryOffset: memoryOffset, dataOffset: dataOffset, size: size, data: m.data) {
+            m.machineStatus = Machine.MachineStatus.Exit(err)
+        }
+    }
+>>>>>>> Stashed changes
 }

--- a/Sources/Interpreter/Machine.swift
+++ b/Sources/Interpreter/Machine.swift
@@ -129,6 +129,10 @@ public struct Machine {
         table[Opcode.CODESIZE.index] = SystemInstructions.codeSize
         table[Opcode.CODECOPY.index] = SystemInstructions.codeCopy
         table[Opcode.CALLDATASIZE.index] = SystemInstructions.callDataSize
+<<<<<<< Updated upstream
+=======
+        table[Opcode.CALLDATACOPY.index] = SystemInstructions.callDataCopy
+>>>>>>> Stashed changes
 
         // Control
         table[Opcode.STOP.index] = ControlInstructions.stop

--- a/Sources/Interpreter/Machine.swift
+++ b/Sources/Interpreter/Machine.swift
@@ -129,10 +129,8 @@ public struct Machine {
         table[Opcode.CODESIZE.index] = SystemInstructions.codeSize
         table[Opcode.CODECOPY.index] = SystemInstructions.codeCopy
         table[Opcode.CALLDATASIZE.index] = SystemInstructions.callDataSize
-<<<<<<< Updated upstream
-=======
         table[Opcode.CALLDATACOPY.index] = SystemInstructions.callDataCopy
->>>>>>> Stashed changes
+        table[Opcode.CALLDATALOAD.index] = SystemInstructions.callDataLoad
 
         // Control
         table[Opcode.STOP.index] = ControlInstructions.stop

--- a/Tests/InterpreterTests/InstructionsTests/System/CallDataLoadTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/System/CallDataLoadTests.swift
@@ -1,0 +1,86 @@
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class InstructionCallDataLoadSpec: QuickSpec {
+    override class func spec() {
+        describe("Instruction CALLDATALOAD") {
+            it("index = 2") {
+                let callData: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05]
+                var m = TestMachine.machine(data: callData, opcode: Opcode.CALLDATALOAD, gasLimit: 10)
+                let _ = m.stack.push(value: U256(from: 2))
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+
+                let result = m.stack.pop()
+                var expected = [UInt8](repeating: 0, count: 32)
+                expected.replaceSubrange(0 ..< 3, with: [0x03, 0x04, 0x05])
+                expect(result).to(beSuccess { value in
+                    expect(value).to(equal(U256.fromBigEndian(from: expected)))
+                })
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(7))
+            }
+
+            it("index more than uint data count") {
+                let callData: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05]
+                var m = TestMachine.machine(data: callData, opcode: Opcode.CALLDATALOAD, gasLimit: 10)
+                let _ = m.stack.push(value: U256(from: 6))
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                let result = m.stack.pop()
+                expect(result).to(beSuccess { value in
+                    expect(value).to(equal(U256.ZERO))
+                })
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(7))
+            }
+
+            it("index more than uint max size") {
+                let callData: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05]
+                var m = TestMachine.machine(data: callData, opcode: Opcode.CALLDATALOAD, gasLimit: 10)
+                let _ = m.stack.push(value: U256(from: [UInt64.max, 1, 0, 0]))
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                let result = m.stack.pop()
+                expect(result).to(beSuccess { value in
+                    expect(value).to(equal(U256.ZERO))
+                })
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(7))
+            }
+
+            it("with OutOfGas result") {
+                var m = TestMachine.machine(data: [], opcode: Opcode.CALLDATALOAD, gasLimit: 1)
+                let _ = m.stack.push(value: U256(from: 5))
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(1))
+                expect(m.gas.remaining).to(equal(1))
+            }
+
+            it("check stack underflow") {
+                let callData: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05]
+                var m = TestMachine.machine(data: callData, opcode: Opcode.CALLDATALOAD, gasLimit: 10)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(7))
+            }
+        }
+    }
+}

--- a/Tests/InterpreterTests/MachineTests.swift
+++ b/Tests/InterpreterTests/MachineTests.swift
@@ -21,6 +21,14 @@ enum TestMachine {
         Machine(data: data, code: [opcode.rawValue], gasLimit: gasLimit, handler: TestHandler())
     }
 
+<<<<<<< Updated upstream
+=======
+    /// Init Machine with Call Input Data and predefined code with array `Opcode` type and `memoryLimit`
+    static func machine(data: [UInt8], opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: UInt) -> Machine {
+        Machine(data: data, code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, handler: TestHandler(), hardFork: HardFork.latest())
+    }
+
+>>>>>>> Stashed changes
     /// Init Machine with predefined code with array `Opcode` type
     static func machine(opcodes code: [Opcode], gasLimit: UInt64) -> Machine {
         Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, handler: TestHandler())

--- a/Tests/InterpreterTests/MachineTests.swift
+++ b/Tests/InterpreterTests/MachineTests.swift
@@ -21,14 +21,11 @@ enum TestMachine {
         Machine(data: data, code: [opcode.rawValue], gasLimit: gasLimit, handler: TestHandler())
     }
 
-<<<<<<< Updated upstream
-=======
     /// Init Machine with Call Input Data and predefined code with array `Opcode` type and `memoryLimit`
     static func machine(data: [UInt8], opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: UInt) -> Machine {
         Machine(data: data, code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, handler: TestHandler(), hardFork: HardFork.latest())
     }
 
->>>>>>> Stashed changes
     /// Init Machine with predefined code with array `Opcode` type
     static func machine(opcodes code: [Opcode], gasLimit: UInt64) -> Machine {
         Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, handler: TestHandler())


### PR DESCRIPTION
## Description

🚀 Added new instructions and tests
➡️ Small refactoring of existing tests

### New instructions
- [x] `CALLDATACOPY`
- [x] `CALLDATALOAD`
