### PR TITLE
Feat: refactoring for Int operations instead of UInt for arrays

### DIFF
--- a/Sources/Interpreter/Instructions/MemoryInstructions.swift
+++ b/Sources/Interpreter/Instructions/MemoryInstructions.swift
@@ -11,8 +11,9 @@ enum MemoryInstructions {
             return
         }
 
-        // This situation possible only for 32-bit context (for example wasm32)
-        guard let index = rawIndex.getUInt else { m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas)); return }
+        guard let index = m.getIntOrFail(rawIndex) else {
+            return
+        }
 
         guard m.resizeMemoryAndRecordGas(offset: index, size: 32) else {
             return
@@ -26,14 +27,17 @@ enum MemoryInstructions {
             return
         }
 
-        guard let rawIndex = m.stackPop(),
-              let value = m.stackPop()
-        else {
+        // Pop data
+        guard let rawIndex = m.stackPop() else {
+            return
+        }
+        guard let value = m.stackPop() else {
             return
         }
 
-        // This situation possible only for 32-bit context (for example wasm32)
-        guard let index = rawIndex.getUInt else { m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas)); return }
+        guard let index = m.getIntOrFail(rawIndex) else {
+            return
+        }
 
         guard m.resizeMemoryAndRecordGas(offset: index, size: 32) else {
             return
@@ -49,14 +53,17 @@ enum MemoryInstructions {
             return
         }
 
-        guard let rawIndex = m.stackPop(),
-              let value = m.stackPop()
-        else {
+        // Pop data
+        guard let rawIndex = m.stackPop() else {
+            return
+        }
+        guard let value = m.stackPop() else {
             return
         }
 
-        // This situation possible only for 32-bit context (for example wasm32)
-        guard let index = rawIndex.getUInt else { m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas)); return }
+        guard let index = m.getIntOrFail(rawIndex) else {
+            return
+        }
 
         guard m.resizeMemoryAndRecordGas(offset: index, size: 1) else {
             return

--- a/Sources/Interpreter/Machine.swift
+++ b/Sources/Interpreter/Machine.swift
@@ -17,7 +17,7 @@ public struct Machine {
     /// Program counter.
     private(set) var pc: Int = 0
     /// Return range for `RETURN` and `REVERT`.
-    var returnRange: Range<UInt> = 0 ..< 0
+    var returnRange: Range<Int> = 0 ..< 0
     /// A map of valid `jump` destinations.
     private var jumpTable: [Bool] = []
     /// Machine Memory.
@@ -85,7 +85,6 @@ public struct Machine {
         case OutOfFund
         case InvalidOpcode(UInt8)
         case MemoryOperation(MemoryError)
-        case UIntOverflow
         case HardForkNotActive
     }
 
@@ -234,7 +233,7 @@ public struct Machine {
         #endif
     }
 
-    init(data: [UInt8], code: [UInt8], gasLimit: UInt64, memoryLimit: UInt, handler: InterpreterHandler, hardFork: HardFork) {
+    init(data: [UInt8], code: [UInt8], gasLimit: UInt64, memoryLimit: Int, handler: InterpreterHandler, hardFork: HardFork) {
         self.data = data
         self.code = code
         self.jumpTable = Self.analyzeJumpTable(code: code)
@@ -398,7 +397,7 @@ public struct Machine {
     ///   - offset: The starting offset from which the memory should be resized.
     ///   - size: The new size to which the memory should be resized.
     /// - Returns: A Boolean value indicating whether the memory was successfully resized and the gas cost recorded.
-    mutating func resizeMemoryAndRecordGas(offset: UInt, size: UInt) -> Bool {
+    mutating func resizeMemoryAndRecordGas(offset: Int, size: Int) -> Bool {
         // Calculate the gas cost for resizing memory.
         let resizeMemoryCost = self.gas.memoryGas.resize(end: offset, length: size)
         switch resizeMemoryCost {
@@ -427,16 +426,16 @@ public struct Machine {
         return true
     }
 
-    /// Get `UInt` from `U256`. If fails return `nil` and set `Machine` status error to `UIntOverflow`.
+    /// Get `Int` from `U256`. If fails return `nil` and set `Machine` status error to `IntOverflow`.
     ///
     /// - Parameters:
     ///   - value: `U256` for converting
     /// - Returns: optional `UInt` value
-    mutating func getUintOrFail(_ value: U256) -> UInt? {
-        guard let uintValue = value.getUInt else {
-            self.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.UIntOverflow))
+    mutating func getIntOrFail(_ value: U256) -> Int? {
+        guard let intValue = value.getInt else {
+            self.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.IntOverflow))
             return nil
         }
-        return uintValue
+        return intValue
     }
 }

--- a/Tests/InterpreterTests/GasTests.swift
+++ b/Tests/InterpreterTests/GasTests.swift
@@ -294,20 +294,20 @@ final class InterpreterGasSpec: QuickSpec {
 
             context("costPerWord") {
                 it("success") {
-                    let size: UInt = 70
-                    let multiple: UInt = 10
-                    let nunWOrd: UInt = 3
-                    let expected: UInt = nunWOrd * multiple
+                    let size: Int = 70
+                    let multiple: Int = 10
+                    let nunWOrd: Int = 3
+                    let expected: UInt64 = UInt64(nunWOrd * multiple)
                     guard let res = GasCost.costPerWord(size: size, multiple: multiple) else {
                         fail("Expected non-nil result")
                         return
                     }
-                    expect(res).to(equal(expected))
+                    expect(res).to(equal(expected ))
                 }
 
                 it("overflow") {
-                    let size: UInt = 70
-                    let multiple = UInt.max
+                    let size: Int = 70
+                    let multiple = Int.max
 
                     let res = GasCost.costPerWord(size: size, multiple: multiple)
                     expect(res).to(beNil())
@@ -316,7 +316,7 @@ final class InterpreterGasSpec: QuickSpec {
 
             context("veryLowCopy") {
                 it("success") {
-                    let size: UInt = 33
+                    let size: Int = 33
                     // VERYLOW + numWords * VERYLOW
                     let expected: UInt64 = 3 + 2 * 3
 
@@ -325,7 +325,7 @@ final class InterpreterGasSpec: QuickSpec {
                 }
 
                 it("check max size not overflow") {
-                    let size = UInt.max
+                    let size = Int.max
                     let cost = GasCost.costPerWord(size: size, multiple: 3)!
                     let expected: UInt64 = 3 + UInt64(cost)
 
@@ -336,7 +336,7 @@ final class InterpreterGasSpec: QuickSpec {
 
             context("memoryGas") {
                 it("success") {
-                    let numWords: UInt64 = 3
+                    let numWords: Int = 3
                     // Gas.Memory numWords + numWords * numWords
                     let expected = 3 * numWords + numWords * numWords
 
@@ -346,9 +346,9 @@ final class InterpreterGasSpec: QuickSpec {
                 }
 
                 it("overflow") {
-                    let numWords: UInt = Memory.numWords(UInt.max)
+                    let numWords: Int = Memory.numWords(Int.max)
 
-                    let (res, overflow) = GasCost.memoryGas(numWords: UInt64(numWords))
+                    let (res, overflow) = GasCost.memoryGas(numWords: numWords)
                     expect(overflow).to(beTrue())
                     expect(res).to(equal(UInt64(0)))
                 }
@@ -357,7 +357,7 @@ final class InterpreterGasSpec: QuickSpec {
             context("memory resize gas cost") {
                 it("overflow for end") {
                     var gas = Gas(limit: 1024)
-                    let res = gas.memoryGas.resize(end: UInt.max, length: 1)
+                    let res = gas.memoryGas.resize(end: Int.max, length: 1)
                     expect(res).to(beFailure { error in
                         expect(error).to(matchError(Machine.ExitError.OutOfGas))
                     })
@@ -365,7 +365,7 @@ final class InterpreterGasSpec: QuickSpec {
 
                 it("overflow for length") {
                     var gas = Gas(limit: 1024)
-                    let res = gas.memoryGas.resize(end: 1, length: UInt.max)
+                    let res = gas.memoryGas.resize(end: 1, length: Int.max)
                     expect(res).to(beFailure { error in
                         expect(error).to(matchError(Machine.ExitError.OutOfGas))
                     })
@@ -373,7 +373,7 @@ final class InterpreterGasSpec: QuickSpec {
 
                 it("overflow for numWords") {
                     var gas = Gas(limit: 1024)
-                    let res = gas.memoryGas.resize(end: UInt.max/2 - 1, length: UInt.max/2 - 1)
+                    let res = gas.memoryGas.resize(end: Int.max/2 - 1, length: Int.max/2 - 1)
                     expect(res).to(beFailure { error in
                         expect(error).to(matchError(Machine.ExitError.OutOfGas))
                     })

--- a/Tests/InterpreterTests/InstructionsTests/Control/ReturnTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Control/ReturnTests.swift
@@ -42,12 +42,13 @@ final class InstructionReturnSpec: QuickSpec {
                 expect(m2.gas.memoryGas.gasCost).to(equal(0))
             }
 
-            it("check stack UInt failure is as expected") {
+            it("check stack Int failure is as expected") {
                 var m1 = Self.machine
                 let _ = m1.stack.push(value: U256(from: 1))
                 let _ = m1.stack.push(value: U256(from: [1, 1, 0, 0]))
                 m1.evalLoop()
-                expect(m1.machineStatus).to(equal(.Exit(.Error(.UIntOverflow))))
+
+                expect(m1.machineStatus).to(equal(.Exit(.Error(.IntOverflow))))
                 expect(m1.gas.remaining).to(equal(100))
                 expect(m1.gas.memoryGas.numWords).to(equal(0))
                 expect(m1.gas.memoryGas.gasCost).to(equal(0))
@@ -56,7 +57,8 @@ final class InstructionReturnSpec: QuickSpec {
                 let _ = m2.stack.push(value: U256(from: [1, 1, 0, 0]))
                 let _ = m2.stack.push(value: U256(from: 1))
                 m2.evalLoop()
-                expect(m2.machineStatus).to(equal(.Exit(.Error(.UIntOverflow))))
+
+                expect(m2.machineStatus).to(equal(.Exit(.Error(.IntOverflow))))
                 expect(m2.gas.remaining).to(equal(100))
                 expect(m2.gas.memoryGas.numWords).to(equal(0))
                 expect(m2.gas.memoryGas.gasCost).to(equal(0))

--- a/Tests/InterpreterTests/InstructionsTests/Control/RevertTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Control/RevertTests.swift
@@ -42,12 +42,12 @@ final class InstructionRevertSpec: QuickSpec {
                 expect(m2.gas.memoryGas.gasCost).to(equal(0))
             }
 
-            it("check stack UInt failure is as expected") {
+            it("check stack Int failure is as expected") {
                 var m1 = Self.machine
                 let _ = m1.stack.push(value: U256(from: 1))
                 let _ = m1.stack.push(value: U256(from: [1, 1, 0, 0]))
                 m1.evalLoop()
-                expect(m1.machineStatus).to(equal(.Exit(.Error(.UIntOverflow))))
+                expect(m1.machineStatus).to(equal(.Exit(.Error(.IntOverflow))))
                 expect(m1.gas.remaining).to(equal(100))
                 expect(m1.gas.memoryGas.numWords).to(equal(0))
                 expect(m1.gas.memoryGas.gasCost).to(equal(0))
@@ -56,7 +56,7 @@ final class InstructionRevertSpec: QuickSpec {
                 let _ = m2.stack.push(value: U256(from: [1, 1, 0, 0]))
                 let _ = m2.stack.push(value: U256(from: 1))
                 m2.evalLoop()
-                expect(m2.machineStatus).to(equal(.Exit(.Error(.UIntOverflow))))
+                expect(m2.machineStatus).to(equal(.Exit(.Error(.IntOverflow))))
                 expect(m2.gas.remaining).to(equal(100))
                 expect(m2.gas.memoryGas.numWords).to(equal(0))
                 expect(m2.gas.memoryGas.gasCost).to(equal(0))

--- a/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MStore8Tests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MStore8Tests.swift
@@ -72,6 +72,19 @@ final class MStore8Spec: QuickSpec {
                 expect(m.gas.memoryGas.gasCost).to(equal(28))
             }
 
+            it("check stack Int failure is as expected") {
+                var m = TestMachine.machine(opcodes: [Opcode.MSTORE8], gasLimit: 100, memoryLimit: 100)
+                let _ = m.stack.push(value: U256(from: 1))
+                let _ = m.stack.push(value: U256(from: [1, 1, 0, 0]))
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.IntOverflow))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(97))
+                expect(m.gas.memoryGas.numWords).to(equal(0))
+                expect(m.gas.memoryGas.gasCost).to(equal(0))
+            }
+
             it("success") {
                 var m = TestMachine.machine(opcode: Opcode.MSTORE8, gasLimit: 100)
 

--- a/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MStoreTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MStoreTests.swift
@@ -72,6 +72,19 @@ final class MStoreSpec: QuickSpec {
                 expect(m.gas.memoryGas.gasCost).to(equal(40))
             }
 
+            it("check stack Int failure is as expected") {
+                var m = TestMachine.machine(opcodes: [Opcode.MSTORE], gasLimit: 100, memoryLimit: 100)
+                let _ = m.stack.push(value: U256(from: 1))
+                let _ = m.stack.push(value: U256(from: [1, 1, 0, 0]))
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.IntOverflow))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(97))
+                expect(m.gas.memoryGas.numWords).to(equal(0))
+                expect(m.gas.memoryGas.gasCost).to(equal(0))
+            }
+
             it("success") {
                 var m = TestMachine.machine(opcode: Opcode.MSTORE, gasLimit: 100)
                 var value = [UInt8](repeating: 0, count: 32)

--- a/Tests/InterpreterTests/InstructionsTests/System/CallDataLoadTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/System/CallDataLoadTests.swift
@@ -26,7 +26,7 @@ final class InstructionCallDataLoadSpec: QuickSpec {
                 expect(m.gas.remaining).to(equal(7))
             }
 
-            it("index more than uint data count") {
+            it("index more than int data count") {
                 let callData: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05]
                 var m = TestMachine.machine(data: callData, opcode: Opcode.CALLDATALOAD, gasLimit: 10)
                 let _ = m.stack.push(value: U256(from: 6))
@@ -43,7 +43,7 @@ final class InstructionCallDataLoadSpec: QuickSpec {
                 expect(m.gas.remaining).to(equal(7))
             }
 
-            it("index more than uint max size") {
+            it("index more than int max size") {
                 let callData: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05]
                 var m = TestMachine.machine(data: callData, opcode: Opcode.CALLDATALOAD, gasLimit: 10)
                 let _ = m.stack.push(value: U256(from: [UInt64.max, 1, 0, 0]))

--- a/Tests/InterpreterTests/MachineTests.swift
+++ b/Tests/InterpreterTests/MachineTests.swift
@@ -6,14 +6,14 @@ import Quick
 final class InterpreterMachineTestsSpec: QuickSpec {
     override class func spec() {
         describe("Machine tests") {
-            it("UInt or fail tests") {
+            it("Int or fail tests") {
                 var m1 = TestMachine.machine(opcodes: [], gasLimit: 1)
-                let res1 = m1.getUintOrFail(U256(from: [1, 1, 0, 0]))
-                expect(m1.machineStatus).to(equal(.Exit(.Error(.UIntOverflow))))
+                let res1 = m1.getIntOrFail(U256(from: [1, 1, 0, 0]))
+                expect(m1.machineStatus).to(equal(.Exit(.Error(.IntOverflow))))
                 expect(res1).to(beNil())
 
                 var m2 = TestMachine.machine(opcodes: [], gasLimit: 1)
-                let res2 = m2.getUintOrFail(U256(from: 10))
+                let res2 = m2.getIntOrFail(U256(from: 10))
                 expect(m2.machineStatus).to(equal(.NotStarted))
                 expect(res2).to(equal(10))
             }

--- a/Tests/InterpreterTests/MachineTestsUtil.swift
+++ b/Tests/InterpreterTests/MachineTestsUtil.swift
@@ -22,7 +22,7 @@ enum TestMachine {
     }
 
     /// Init Machine with Call Input Data and predefined code with array `Opcode` type and `memoryLimit`
-    static func machine(data: [UInt8], opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: UInt) -> Machine {
+    static func machine(data: [UInt8], opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: Int) -> Machine {
         Machine(data: data, code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, handler: TestHandler(), hardFork: HardFork.latest())
     }
 
@@ -32,12 +32,12 @@ enum TestMachine {
     }
 
     /// Init Machine with predefined code with array `Opcode` type and `memoryLimit`
-    static func machine(opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: UInt) -> Machine {
+    static func machine(opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: Int) -> Machine {
         Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, handler: TestHandler(), hardFork: HardFork.latest())
     }
 
     /// Init Machine with predefined code with array `Opcode` type and `memoryLimit`, and hardFork
-    static func machine(opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: UInt, HardFork: HardFork) -> Machine {
+    static func machine(opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: Int, HardFork: HardFork) -> Machine {
         Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, handler: TestHandler(), hardFork: HardFork)
     }
 

--- a/Tests/InterpreterTests/MemoryTests.swift
+++ b/Tests/InterpreterTests/MemoryTests.swift
@@ -111,7 +111,7 @@ final class InterpreterMemorySpec: QuickSpec {
 
                 it("check is new size is filled with zeros") {
                     let memory = Memory(limit: 100)
-                    let res1 = memory.resize(offset: UInt.max, size: 3)
+                    let res1 = memory.resize(offset: Int.max, size: 3)
                     expect(res1).to(beFalse())
                     expect(memory.effectiveLength).to(equal(0))
                 }
@@ -315,7 +315,7 @@ final class InterpreterMemorySpec: QuickSpec {
                 }
 
                 it("overflow operation") {
-                    expect(Memory.ceil32(UInt.max)).to(equal(UInt.max - 31))
+                    expect(Memory.ceil32(Int.max)).to(equal(Int.max - 31))
                 }
             }
 
@@ -335,7 +335,7 @@ final class InterpreterMemorySpec: QuickSpec {
                 }
 
                 it("overflow operation") {
-                    expect(Memory.numWords(UInt.max)).to(equal(UInt.max / 32))
+                    expect(Memory.numWords(Int.max)).to(equal(Int.max / 32))
                 }
             }
         }


### PR DESCRIPTION
## Description

⏫ Refactored `UInt` transformation for EVM instructions to `Int`. **Motivation**: Swift array index supports only `Int` type. And it's a lot of transformations in EVM from `UInt` to `Int`. To avoud that, all transformations from `U256` refactored to `Int` types insted of `UInt`
➡️ Refactored tests and added `Int` failure transformations tests