### PR TITLE
Feat: add BALANCE opcode logic and State Execution

### DIFF
--- a/Sources/Interpreter/ExecutionState.swift
+++ b/Sources/Interpreter/ExecutionState.swift
@@ -1,1 +1,60 @@
-struct ExecutionState {}
+import PrimitiveTypes
+
+final class ExecutionState {
+    struct StorageKey: Hashable {
+        let address: H160
+        let key: H256
+    }
+
+    struct AccessedState {
+        var addresses: Set<H160>
+        var code: Set<H256>
+        var storage: Set<StorageKey>
+        var authority: [H160: H160]
+    }
+
+    /// Parent `ExecutionState`
+    var parent: ExecutionState?
+    /// Execution state accessed data
+    var accessed: AccessedState
+    /// Execution state call depth
+    var depth: UInt16 = 0
+
+    init() {
+        self.accessed = AccessedState(
+            addresses: Set<H160>(),
+            code: Set<H256>(),
+            storage: Set<StorageKey>(),
+            authority: [H160: H160]()
+        )
+    }
+
+    /// Determines if an address is considered "cold" (not previously accessed).
+    ///
+    /// An address is considered cold if it has not been accessed in the current execution context
+    /// or any parent execution context. This is typically used for EIP-2929 gas cost calculations
+    /// where accessing a cold address incurs higher gas costs than accessing a warm address.
+    ///
+    /// - Parameter address: The address to check for cold access status
+    /// - Returns: `true` if the address is cold (not previously accessed), `false` if it's warm (previously accessed)
+    func isCold(address: H160) -> Bool {
+        if self.accessed.addresses.contains(address) {
+            return false
+        } else {
+            return self.parent?.isCold(address: address) ?? true
+        }
+    }
+
+    /// Marks an address as "warm" by adding it to the set of accessed addresses.
+    ///
+    /// In EIP-2929, addresses that have been accessed during transaction execution
+    /// are considered "warm" and subsequent operations on these addresses consume
+    /// less gas than "cold" operations on previously unaccessed addresses.
+    ///
+    /// - Parameter address: The address to mark as warm/accessed
+    func warm(address: H160, isCold: Bool = true) {
+        if isCold {
+            self.accessed.addresses.insert(address)
+        }
+    }
+}

--- a/Sources/Interpreter/Instructions/Arithmetic.swift
+++ b/Sources/Interpreter/Instructions/Arithmetic.swift
@@ -179,7 +179,6 @@ enum ArithmeticInstructions {
         }
 
         if !m.gasRecordCost(cost: GasCost.expCost(hardFork: m.hardFork, power: op2)) {
-            m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
             return
         }
 

--- a/Sources/Interpreter/Instructions/Host.swift
+++ b/Sources/Interpreter/Instructions/Host.swift
@@ -1,0 +1,30 @@
+import PrimitiveTypes
+
+/// EVM Host instructions
+enum HostInstructions {
+    static func balance(machine m: Machine) {
+        guard let address = m.stackPopH256()?.toH160() else {
+            return
+        }
+
+        // Calculate gas depending on hard fork
+        var gasCost: UInt64 = 0
+        if m.hardFork.isBerlin() {
+            let isCold = m.state.isCold(address: address)
+            m.state.warm(address: address, isCold: isCold)
+            gasCost = GasCost.warmOrColdCost(isCold: isCold)
+        } else if m.hardFork.isIstanbul() {
+            // EIP-1884: Repricing for trie-size-dependent opcodes
+            gasCost = 700
+        } else if m.hardFork.isTangerine() {
+            gasCost = 400
+        } else {
+            gasCost = 20
+        }
+        if !m.gasRecordCost(cost: gasCost) {
+            return
+        }
+
+        m.stackPush(value: m.handler.balance(address: address))
+    }
+}

--- a/Sources/Interpreter/InterpreterHanlder.swift
+++ b/Sources/Interpreter/InterpreterHanlder.swift
@@ -1,0 +1,11 @@
+import PrimitiveTypes
+
+/// Interpreter handler used to pass Handler functions to Interpreter to
+/// extend functionality for specific needs
+public protocol InterpreterHandler {
+    /// Run function before `Opcode` execution ay evaluation stage in Machine
+    func beforeOpcodeExecution(machine: Machine, opcode: Opcode?) -> Machine
+        .ExitError?
+
+    func balance(address: H160) -> U256
+}

--- a/Sources/Interpreter/Runtime.swift
+++ b/Sources/Interpreter/Runtime.swift
@@ -3,7 +3,7 @@ import PrimitiveTypes
 public final class Runtime {
     var machine: Machine
 
-    init(code: [UInt8], data: [UInt8], gasLimit: UInt64, context: Machine.Context, handler: InterpreterHandler) {
-        self.machine = Machine(data: data, code: code, gasLimit: 0, context: context, handler: handler)
+    init(code: [UInt8], data: [UInt8], gasLimit: UInt64, context: Machine.Context, state: ExecutionState, handler: InterpreterHandler) {
+        self.machine = Machine(data: data, code: code, gasLimit: 0, context: context, state: state, handler: handler)
     }
 }

--- a/Sources/PrimitiveTypes/H160.swift
+++ b/Sources/PrimitiveTypes/H160.swift
@@ -1,4 +1,4 @@
-public struct H160: FixedArray {
+public struct H160: FixedArray, Hashable {
     private var bytes: [UInt8]
 
     public static let numberBytes: UInt8 = 20
@@ -10,5 +10,9 @@ public struct H160: FixedArray {
     public init(from bytes: [UInt8]) {
         precondition(bytes.count == Self.numberBytes, "H160 must be initialized with \(Self.numberBytes) bytes array.")
         self.bytes = bytes
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(BYTES)
     }
 }

--- a/Sources/PrimitiveTypes/H256.swift
+++ b/Sources/PrimitiveTypes/H256.swift
@@ -18,4 +18,15 @@ public struct H256: FixedArray {
         newArray.replaceSubrange(12 ..< 32, with: value.BYTES)
         self.bytes = newArray
     }
+
+    /// Covert `H256` to `H160` by taking the last 20 bytes
+    /// Optimizations:  only one array copy (analog of `memcpy`)
+    public func toH160() -> H160 {
+        return bytes.withUnsafeBufferPointer { ptr in
+            let base = ptr.baseAddress! + 12
+            let buffer = UnsafeBufferPointer(start: base, count: 20)
+            // Only one copy
+            return H160(from: Array(buffer))
+        }
+    }
 }

--- a/Sources/PrimitiveTypes/H256.swift
+++ b/Sources/PrimitiveTypes/H256.swift
@@ -1,4 +1,4 @@
-public struct H256: FixedArray {
+public struct H256: FixedArray, Hashable {
     private var bytes: [UInt8]
 
     public static let numberBytes: UInt8 = 32
@@ -28,5 +28,9 @@ public struct H256: FixedArray {
             // Only one copy
             return H160(from: Array(buffer))
         }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(BYTES)
     }
 }

--- a/Tests/InterpreterTests/ExecutionStateTests.swift
+++ b/Tests/InterpreterTests/ExecutionStateTests.swift
@@ -1,0 +1,38 @@
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class ExecutionStateSpec: QuickSpec {
+    override class func spec() {
+        describe("ExecutionState") {
+            context("warm and cold addresses") {
+                it("warm address and check is cold") {
+                    let addr1 = TestHandler.address1
+                    let addr2 = TestHandler.address2
+
+                    let state = ExecutionState()
+                    expect(state.isCold(address: addr1)).to(beTrue())
+                    expect(state.isCold(address: addr2)).to(beTrue())
+
+                    state.warm(address: addr1)
+                    expect(state.isCold(address: addr1)).to(beFalse())
+                    expect(state.isCold(address: addr2)).to(beTrue())
+                }
+
+                it("warm address with additional param") {
+                    let addr1 = TestHandler.address1
+
+                    let state = ExecutionState()
+                    expect(state.isCold(address: addr1)).to(beTrue())
+
+                    state.warm(address: addr1, isCold: false)
+                    expect(state.isCold(address: addr1)).to(beTrue())
+
+                    state.warm(address: addr1, isCold: true)
+                    expect(state.isCold(address: addr1)).to(beFalse())
+                }
+            }
+        }
+    }
+}

--- a/Tests/InterpreterTests/GasTests.swift
+++ b/Tests/InterpreterTests/GasTests.swift
@@ -294,19 +294,19 @@ final class InterpreterGasSpec: QuickSpec {
 
             context("costPerWord") {
                 it("success") {
-                    let size: Int = 70
-                    let multiple: Int = 10
-                    let nunWOrd: Int = 3
-                    let expected: UInt64 = UInt64(nunWOrd * multiple)
+                    let size = 70
+                    let multiple = 10
+                    let nunWOrd = 3
+                    let expected = UInt64(nunWOrd * multiple)
                     guard let res = GasCost.costPerWord(size: size, multiple: multiple) else {
                         fail("Expected non-nil result")
                         return
                     }
-                    expect(res).to(equal(expected ))
+                    expect(res).to(equal(expected))
                 }
 
                 it("overflow") {
-                    let size: Int = 70
+                    let size = 70
                     let multiple = Int.max
 
                     let res = GasCost.costPerWord(size: size, multiple: multiple)
@@ -316,7 +316,7 @@ final class InterpreterGasSpec: QuickSpec {
 
             context("veryLowCopy") {
                 it("success") {
-                    let size: Int = 33
+                    let size = 33
                     // VERYLOW + numWords * VERYLOW
                     let expected: UInt64 = 3 + 2 * 3
 
@@ -336,7 +336,7 @@ final class InterpreterGasSpec: QuickSpec {
 
             context("memoryGas") {
                 it("success") {
-                    let numWords: Int = 3
+                    let numWords = 3
                     // Gas.Memory numWords + numWords * numWords
                     let expected = 3 * numWords + numWords * numWords
 
@@ -405,7 +405,95 @@ final class InterpreterGasSpec: QuickSpec {
                     expect(res2).to(beSuccess(.Resized(18)))
                     expect(gas.memoryGas.gasCost).to(equal(28))
                 }
+            }
 
+            context("expCosr") {
+                it("pow 0") {
+                    let result = GasCost.expCost(hardFork: HardFork.SpuriousDragon, power: U256.ZERO)
+                    let expected: UInt64 = GasConstant.EXP
+
+                    expect(result).to(equal(expected))
+                }
+
+                it("pow 6") {
+                    let result = GasCost.expCost(hardFork: HardFork.SpuriousDragon, power: U256(from: 6))
+                    let expected: UInt64 = 60
+
+                    expect(result).to(equal(expected))
+                }
+
+                it("pow 6 - Tangerine hard fork") {
+                    let result = GasCost.expCost(hardFork: HardFork.Tangerine, power: U256(from: 6))
+                    let expected: UInt64 = 20
+
+                    expect(result).to(equal(expected))
+                }
+            }
+
+            context("log2floor") {
+                it("log2floor [0,0,0,0]") {
+                    let u256Value = U256(from: [0, 0, 0, 0])
+                    let result = GasCost.log2floor(u256Value)
+                    let expected: UInt64 = 0
+
+                    expect(result).to(equal(expected))
+                }
+
+                it("log2floor [2,0,0,0]") {
+                    let u256Value = U256(from: [2, 0, 0, 0])
+                    let result = GasCost.log2floor(u256Value)
+                    let expected: UInt64 = 1
+
+                    expect(result).to(equal(expected))
+                }
+
+                it("log2floor [1,0,0,0]") {
+                    let u256Value = U256(from: [1, 0, 0, 0])
+                    let result = GasCost.log2floor(u256Value)
+                    let expected: UInt64 = 0
+
+                    expect(result).to(equal(expected))
+                }
+
+                it("log2floor [0,1,0,0]") {
+                    let u256Value = U256(from: [0, 1, 0, 0])
+                    let result = GasCost.log2floor(u256Value)
+                    let expected: UInt64 = 64
+
+                    expect(result).to(equal(expected))
+                }
+
+                it("log2floor [0,0,1,0]") {
+                    let u256Value = U256(from: [0, 0, 1, 0])
+                    let result = GasCost.log2floor(u256Value)
+                    let expected: UInt64 = 128
+
+                    expect(result).to(equal(expected))
+                }
+
+                it("log2floor [0,0,0,1]") {
+                    let u256Value = U256(from: [0, 0, 0, 1])
+                    let result = GasCost.log2floor(u256Value)
+                    let expected: UInt64 = 192
+
+                    expect(result).to(equal(expected))
+                }
+            }
+
+            context("warm and cold address") {
+                it("warm address") {
+                    let result = GasCost.warmOrColdCost(isCold: false)
+                    let expected: UInt64 = GasConstant.WARM_STORAGE_READ_COST
+
+                    expect(result).to(equal(expected))
+                }
+
+                it("cold address") {
+                    let result = GasCost.warmOrColdCost(isCold: true)
+                    let expected: UInt64 = GasConstant.COLD_ACCOUNT_ACCESS_COST
+
+                    expect(result).to(equal(expected))
+                }
             }
         }
     }

--- a/Tests/InterpreterTests/HardForkTests.swift
+++ b/Tests/InterpreterTests/HardForkTests.swift
@@ -45,12 +45,12 @@ final class InterpreterHardForkSpec: QuickSpec {
 
             context("HardFork in Machine") {
                 it("validate Machine hard fork") {
-                    let m = Machine(data: [], code: [], gasLimit: 100, memoryLimit: 1024, context: TestMachine.defaultContext(), handler: TestHandler(), hardFork: HardFork.London)
+                    let m = Machine(data: [], code: [], gasLimit: 100, memoryLimit: 1024, context: TestMachine.defaultContext(), state: ExecutionState(), handler: TestHandler(), hardFork: HardFork.London)
                     expect(m.hardFork).to(equal(HardFork.London))
                 }
 
                 it("validate Machine hard fork has latest hard fork") {
-                    let m = Machine(data: [], code: [], gasLimit: 100, context: TestMachine.defaultContext(), handler: TestHandler())
+                    let m = Machine(data: [], code: [], gasLimit: 100, context: TestMachine.defaultContext(), state: ExecutionState(), handler: TestHandler())
                     expect(m.hardFork).to(equal(HardFork.latest()))
                 }
             }

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/ExpTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/ExpTests.swift
@@ -32,7 +32,7 @@ final class InstructionExpSpec: QuickSpec {
             }
 
             it("2 exp 6 for Tangerine hard fork") {
-                let m = TestMachine.machine(opcodes: [Opcode.EXP], gasLimit: 75, memoryLimit: 1024, HardFork: HardFork.Tangerine)
+                let m = TestMachine.machine(opcodes: [Opcode.EXP], gasLimit: 75, memoryLimit: 1024, hardFork: .Tangerine)
 
                 let _ = m.stack.push(value: U256(from: 3))
                 let _ = m.stack.push(value: U256(from: 2))
@@ -116,56 +116,6 @@ final class InstructionExpSpec: QuickSpec {
             let _ = m2.stack.push(value: U256(from: 2))
             m2.evalLoop()
             expect(m2.machineStatus).to(equal(.Exit(.Success(.Stop))))
-        }
-
-        context("log2floor logic") {
-            it("log2floor [0,0,0,0]") {
-                let u256Value = U256(from: [0, 0, 0, 0])
-                let result = GasCost.log2floor(u256Value)
-                let expected: UInt64 = 0
-
-                expect(result).to(equal(expected))
-            }
-
-            it("log2floor [2,0,0,0]") {
-                let u256Value = U256(from: [2, 0, 0, 0])
-                let result = GasCost.log2floor(u256Value)
-                let expected: UInt64 = 1
-
-                expect(result).to(equal(expected))
-            }
-
-            it("log2floor [1,0,0,0]") {
-                let u256Value = U256(from: [1, 0, 0, 0])
-                let result = GasCost.log2floor(u256Value)
-                let expected: UInt64 = 0
-
-                expect(result).to(equal(expected))
-            }
-
-            it("log2floor [0,1,0,0]") {
-                let u256Value = U256(from: [0, 1, 0, 0])
-                let result = GasCost.log2floor(u256Value)
-                let expected: UInt64 = 64
-
-                expect(result).to(equal(expected))
-            }
-
-            it("log2floor [0,0,1,0]") {
-                let u256Value = U256(from: [0, 0, 1, 0])
-                let result = GasCost.log2floor(u256Value)
-                let expected: UInt64 = 128
-
-                expect(result).to(equal(expected))
-            }
-
-            it("log2floor [0,0,0,1]") {
-                let u256Value = U256(from: [0, 0, 0, 1])
-                let result = GasCost.log2floor(u256Value)
-                let expected: UInt64 = 192
-
-                expect(result).to(equal(expected))
-            }
         }
     }
 }

--- a/Tests/InterpreterTests/InstructionsTests/Control/RevertTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Control/RevertTests.swift
@@ -5,14 +5,14 @@ import Quick
 
 final class InstructionRevertSpec: QuickSpec {
     @MainActor
-    static let machineLowGas = TestMachine.machine(opcodes: [Opcode.REVERT], gasLimit: 1, memoryLimit: 1024, HardFork: .Byzantium)
+    static let machineLowGas = TestMachine.machine(opcodes: [Opcode.REVERT], gasLimit: 1, memoryLimit: 1024, hardFork: .Byzantium)
     @MainActor
-    static let machine = TestMachine.machine(opcodes: [Opcode.REVERT], gasLimit: 100, memoryLimit: 1024, HardFork: .Byzantium)
+    static let machine = TestMachine.machine(opcodes: [Opcode.REVERT], gasLimit: 100, memoryLimit: 1024, hardFork: .Byzantium)
 
     override class func spec() {
         describe("Instruction REVERT") {
             it("with OutOfGas result for index=0") {
-                 let m = Self.machineLowGas
+                let m = Self.machineLowGas
 
                 let _ = m.stack.push(value: U256(from: 33))
                 let _ = m.stack.push(value: U256(from: 32))
@@ -26,14 +26,14 @@ final class InstructionRevertSpec: QuickSpec {
             }
 
             it("check stack underflow errors is as expected") {
-                 let m1 = Self.machine
+                let m1 = Self.machine
                 m1.evalLoop()
                 expect(m1.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m1.gas.remaining).to(equal(100))
                 expect(m1.gas.memoryGas.numWords).to(equal(0))
                 expect(m1.gas.memoryGas.gasCost).to(equal(0))
 
-                 let m2 = Self.machine
+                let m2 = Self.machine
                 let _ = m2.stack.push(value: U256(from: 0))
                 m2.evalLoop()
                 expect(m2.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
@@ -43,7 +43,7 @@ final class InstructionRevertSpec: QuickSpec {
             }
 
             it("check stack Int failure is as expected") {
-                 let m1 = Self.machine
+                let m1 = Self.machine
                 let _ = m1.stack.push(value: U256(from: 1))
                 let _ = m1.stack.push(value: U256(from: [1, 1, 0, 0]))
                 m1.evalLoop()
@@ -52,7 +52,7 @@ final class InstructionRevertSpec: QuickSpec {
                 expect(m1.gas.memoryGas.numWords).to(equal(0))
                 expect(m1.gas.memoryGas.gasCost).to(equal(0))
 
-                 let m2 = Self.machine
+                let m2 = Self.machine
                 let _ = m2.stack.push(value: U256(from: [1, 1, 0, 0]))
                 let _ = m2.stack.push(value: U256(from: 1))
                 m2.evalLoop()
@@ -63,7 +63,7 @@ final class InstructionRevertSpec: QuickSpec {
             }
 
             it("check hard fork") {
-                 let m1 = TestMachine.machine(opcodes: [Opcode.REVERT], gasLimit: 100, memoryLimit: 1024, HardFork: .SpuriousDragon)
+                let m1 = TestMachine.machine(opcodes: [Opcode.REVERT], gasLimit: 100, memoryLimit: 1024, hardFork: .SpuriousDragon)
                 let _ = m1.stack.push(value: U256(from: 32))
                 let _ = m1.stack.push(value: U256(from: 33))
                 m1.evalLoop()
@@ -74,7 +74,7 @@ final class InstructionRevertSpec: QuickSpec {
             }
 
             it("Success") {
-                 let m = Self.machine
+                let m = Self.machine
 
                 let _ = m.stack.push(value: U256(from: 32))
                 let _ = m.stack.push(value: U256(from: 33))

--- a/Tests/InterpreterTests/InstructionsTests/Host/BalanceTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Host/BalanceTests.swift
@@ -1,0 +1,129 @@
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class InstructionBalanceSpec: QuickSpec {
+    @MainActor
+    static let machineLowGas = TestMachine.machine(opcode: Opcode.BALANCE, gasLimit: 1)
+
+    override class func spec() {
+        describe("Instruction BALANCE") {
+            it("with OutOfGas result") {
+                let m = Self.machineLowGas
+                let val1 = U256.fromBigEndian(from: H256(from: TestHandler.address1).BYTES)
+                let _ = m.stack.push(value: val1)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(1))
+            }
+
+            it("check stack") {
+                let m = TestMachine.machine(opcode: Opcode.BALANCE, gasLimit: 3000)
+                m.evalLoop()
+                expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+
+                let m1 = TestMachine.machine(opcode: Opcode.BALANCE, gasLimit: 3000)
+                let val1 = U256.fromBigEndian(from: H256(from: TestHandler.address1).BYTES)
+                let _ = m1.stack.push(value: val1)
+
+                m1.evalLoop()
+                expect(m1.machineStatus).to(equal(.Exit(.Success(.Stop))))
+            }
+
+            it("get not existed address") {
+                let m = TestMachine.machine(opcode: Opcode.BALANCE, gasLimit: 3000)
+                let _ = m.stack.push(value: U256(from: 1))
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+
+                let result = m.stack.pop()
+                expect(result).to(beSuccess { value in
+                    expect(value).to(equal(U256.ZERO))
+                })
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(400))
+            }
+
+            it("cold and warm address") {
+                let m = TestMachine.machine(opcodes: [Opcode.BALANCE, Opcode.POP, Opcode.BALANCE], gasLimit: 3000)
+                let val1 = U256.fromBigEndian(from: H256(from: TestHandler.address1).BYTES)
+                let _ = m.stack.push(value: val1)
+                let _ = m.stack.push(value: val1)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+
+                let result = m.stack.pop()
+                expect(result).to(beSuccess { value in
+                    expect(value).to(equal(U256(from: 5)))
+                })
+
+                expect(m.stack.length).to(equal(0))
+                // Gas cost = 2600 (cold) + 100 (warm) + 2 (POP opcode)
+                expect(m.gas.remaining).to(equal(298))
+            }
+
+            it("Istanbul hard fork") {
+                let m = TestMachine.machine(opcodes: [Opcode.BALANCE], gasLimit: 3000, memoryLimit: 1024, hardFork: .Istanbul)
+                let val1 = U256.fromBigEndian(from: H256(from: TestHandler.address1).BYTES)
+                let _ = m.stack.push(value: val1)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+
+                let result = m.stack.pop()
+                expect(result).to(beSuccess { value in
+                    expect(value).to(equal(U256(from: 5)))
+                })
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(2300))
+            }
+
+            it("Tangerine hard fork") {
+                let m = TestMachine.machine(opcodes: [Opcode.BALANCE], gasLimit: 3000, memoryLimit: 1024, hardFork: .Tangerine)
+                let val1 = U256.fromBigEndian(from: H256(from: TestHandler.address1).BYTES)
+                let _ = m.stack.push(value: val1)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+
+                let result = m.stack.pop()
+                expect(result).to(beSuccess { value in
+                    expect(value).to(equal(U256(from: 5)))
+                })
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(2600))
+            }
+
+            it("Homestead hard fork") {
+                let m = TestMachine.machine(opcodes: [Opcode.BALANCE], gasLimit: 3000, memoryLimit: 1024, hardFork: .Homestead)
+                let val1 = U256.fromBigEndian(from: H256(from: TestHandler.address1).BYTES)
+                let _ = m.stack.push(value: val1)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+
+                let result = m.stack.pop()
+                expect(result).to(beSuccess { value in
+                    expect(value).to(equal(U256(from: 5)))
+                })
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(2980))
+            }
+        }
+    }
+}

--- a/Tests/InterpreterTests/InstructionsTests/NotExistTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/NotExistTests.swift
@@ -7,7 +7,7 @@ final class InstructionNotExistSpec: QuickSpec {
     override class func spec() {
         describe("Instruction Not Exist (invalid opcode)") {
             it("Not existed opcode") {
-                let m = Machine(data: [], code: [0xEF], gasLimit: 10, context: TestMachine.defaultContext(), handler: TestHandler())
+                let m = Machine(data: [], code: [0xEF], gasLimit: 10, context: TestMachine.defaultContext(), state: ExecutionState(), handler: TestHandler())
 
                 let _ = m.stack.push(value: U256(from: 1))
                 let _ = m.stack.push(value: U256(from: 2))

--- a/Tests/InterpreterTests/InstructionsTests/System/CodeValueTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/System/CodeValueTests.swift
@@ -49,7 +49,7 @@ final class InstructionCallValueSpec: QuickSpec {
             }
 
             it("value = MAX") {
-                var ctx = Machine.Context(target: H160.ZERO, sender: H160.ZERO, value: U256.MAX)
+                let ctx = Machine.Context(target: H160.ZERO, sender: H160.ZERO, value: U256.MAX)
                 let m = TestMachine.machineWithContext(opcode: Opcode.CALLVALUE, gasLimit: 10, context: ctx)
 
                 m.evalLoop()

--- a/Tests/InterpreterTests/MachineTests.swift
+++ b/Tests/InterpreterTests/MachineTests.swift
@@ -4,6 +4,12 @@ import PrimitiveTypes
 import Quick
 
 final class InterpreterMachineTestsSpec: QuickSpec {
+    class CustomHandler: TestHandler {
+        override func beforeOpcodeExecution(machine: Machine, opcode: Opcode?) -> Machine.ExitError? {
+            return .OutOfFund
+        }
+    }
+
     override class func spec() {
         describe("Machine tests") {
             it("Int or fail tests") {
@@ -16,6 +22,13 @@ final class InterpreterMachineTestsSpec: QuickSpec {
                 let res2 = m2.getIntOrFail(U256(from: 10))
                 expect(m2.machineStatus).to(equal(.NotStarted))
                 expect(res2).to(equal(10))
+            }
+
+            it("Machine beforeOpcodeExecution flow") {
+                print("-->")
+                let m = Machine(data: [], code: [Opcode.PC.rawValue], gasLimit: 100, context: TestMachine.defaultContext(), state: ExecutionState(), handler: CustomHandler())
+                m.evalLoop()
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfFund))))
             }
         }
     }

--- a/Tests/InterpreterTests/MachineTestsUtil.swift
+++ b/Tests/InterpreterTests/MachineTestsUtil.swift
@@ -4,9 +4,23 @@
 @testable import Interpreter
 import PrimitiveTypes
 
-struct TestHandler: InterpreterHandler {
-    func beforeOpcodeExecution(machine: Machine, opcode: Opcode, address: H160) -> Machine.ExitError? {
-        nil
+class TestHandler: InterpreterHandler {
+    static let address1: H160 = .fromString(hex: "9A6402EEa6d967dBd7609346c11A1702Db4E5001")
+    static let address2: H160 = .fromString(hex: "9A6402EEa6d967dBd7609346c11A1702Db4E5002")
+
+    func beforeOpcodeExecution(machine: Machine, opcode: Opcode?) -> Machine.ExitError? {
+        return nil
+    }
+
+    func balance(address: H160) -> U256 {
+        switch address {
+        case Self.address1:
+            return U256(from: 5)
+        case Self.address2:
+            return U256(from: 10)
+        default:
+            return U256.ZERO
+        }
     }
 }
 
@@ -17,40 +31,40 @@ enum TestMachine {
 
     /// Init simple Machine
     static func machine(opcode: Opcode, gasLimit: UInt64) -> Machine {
-        Machine(data: [], code: [opcode.rawValue], gasLimit: gasLimit, context: defaultContext(), handler: TestHandler())
+        Machine(data: [], code: [opcode.rawValue], gasLimit: gasLimit, context: defaultContext(), state: ExecutionState(), handler: TestHandler())
     }
 
     /// Init simple Machine with Call Input Data
     static func machine(data: [UInt8], opcode: Opcode, gasLimit: UInt64) -> Machine {
-        Machine(data: data, code: [opcode.rawValue], gasLimit: gasLimit, context: defaultContext(), handler: TestHandler())
+        Machine(data: data, code: [opcode.rawValue], gasLimit: gasLimit, context: defaultContext(), state: ExecutionState(), handler: TestHandler())
     }
 
     /// Init Machine with Call Input Data and predefined code with array `Opcode` type and `memoryLimit`
     static func machine(data: [UInt8], opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: Int) -> Machine {
-        Machine(data: data, code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, context: defaultContext(), handler: TestHandler(), hardFork: HardFork.latest())
+        Machine(data: data, code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, context: defaultContext(), state: ExecutionState(), handler: TestHandler(), hardFork: HardFork.latest())
     }
 
     /// Init Machine with predefined code with array `Opcode` type
     static func machine(opcodes code: [Opcode], gasLimit: UInt64) -> Machine {
-        Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, context: defaultContext(), handler: TestHandler())
+        Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, context: defaultContext(), state: ExecutionState(), handler: TestHandler())
     }
 
     /// Init Machine with predefined code with array `Opcode` type and `memoryLimit`
     static func machine(opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: Int) -> Machine {
-        Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, context: defaultContext(), handler: TestHandler(), hardFork: HardFork.latest())
+        Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, context: defaultContext(), state: ExecutionState(), handler: TestHandler(), hardFork: HardFork.latest())
     }
 
     /// Init Machine with predefined code with array `Opcode` type and `memoryLimit`, and hardFork
-    static func machine(opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: Int, HardFork: HardFork) -> Machine {
-        Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, context: defaultContext(), handler: TestHandler(), hardFork: HardFork)
+    static func machine(opcodes code: [Opcode], gasLimit: UInt64, memoryLimit: Int, hardFork: HardFork) -> Machine {
+        Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, memoryLimit: memoryLimit, context: defaultContext(), state: ExecutionState(), handler: TestHandler(), hardFork: hardFork)
     }
 
     /// Init Machine with predefined code with raw data
     static func machine(rawCode code: [UInt8], gasLimit: UInt64) -> Machine {
-        Machine(data: [], code: code, gasLimit: gasLimit, context: defaultContext(), handler: TestHandler())
+        Machine(data: [], code: code, gasLimit: gasLimit, context: defaultContext(), state: ExecutionState(), handler: TestHandler())
     }
 
     static func machineWithContext(opcode: Opcode, gasLimit: UInt64, context: Machine.Context) -> Machine {
-        Machine(data: [], code: [opcode.rawValue], gasLimit: gasLimit, context: context, handler: TestHandler())
+        Machine(data: [], code: [opcode.rawValue], gasLimit: gasLimit, context: context, state: ExecutionState(), handler: TestHandler())
     }
 }

--- a/Tests/InterpreterTests/RuntimeTests.swift
+++ b/Tests/InterpreterTests/RuntimeTests.swift
@@ -9,7 +9,7 @@ final class RuntimeSpec: QuickSpec {
         describe("Runtime") {
             it("initializes ") {
                 let context = TestMachine.defaultContext()
-                let _ = Runtime(code: [], data: [], gasLimit: 0, context: context, handler: TestHandler())
+                let _ = Runtime(code: [], data: [], gasLimit: 0, context: context, state: ExecutionState(), handler: TestHandler())
             }
         }
     }

--- a/Tests/PrimitiveTypesTests/H160Tests.swift
+++ b/Tests/PrimitiveTypesTests/H160Tests.swift
@@ -81,6 +81,38 @@ final class H160Spec: QuickSpec {
                         expect(H160.fromString(hex: "0000000000000000000000000000000000000000")).to(equal(val))
                     }
                 }
+
+                context("when hashing H160") {
+                    it("produces the same hash for equal values") {
+                        let bytes = [UInt8](repeating: 0xab, count: 20)
+                        let h1 = H160(from: bytes)
+                        let h2 = H160(from: bytes)
+
+                        expect(h1.hashValue).to(equal(h2.hashValue))
+                    }
+
+                    it("produces different hash for different values") {
+                        let h1 = H160(from: [UInt8](repeating: 0x00, count: 20))
+                        let h2 = H160(from: [UInt8](repeating: 0x01, count: 20))
+
+                        expect(h1.hashValue).toNot(equal(h2.hashValue))
+                    }
+
+                    it("can be used in a Set") {
+                        let h1 = H160(from: [UInt8](repeating: 0x01, count: 20))
+                        let h2 = H160(from: [UInt8](repeating: 0x02, count: 20))
+                        let h3 = H160(from: [UInt8](repeating: 0x01, count: 20)) // same as h1
+
+                        var set: Set<H160> = []
+                        set.insert(h1)
+                        set.insert(h2)
+                        set.insert(h3)
+
+                        expect(set.count).to(equal(2))
+                        expect(set.contains(h1)).to(beTrue())
+                        expect(set.contains(h2)).to(beTrue())
+                    }
+                }
             }
         }
     }

--- a/Tests/PrimitiveTypesTests/H256Tests.swift
+++ b/Tests/PrimitiveTypesTests/H256Tests.swift
@@ -95,6 +95,16 @@ final class H256Spec: QuickSpec {
                             .to(equal([UInt8](repeating: 0, count: 12)))
                     }
                 }
+
+                context("when converted to H160 value") {
+                    it("correct data") {
+                        let valH160 = H160(from: [UInt8](repeating: 0xAC, count: 20))
+                        let val = H256(from: valH160)
+
+                        expect(val.BYTES).to(equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC, 0xAC]))
+                        expect(val.toH160()).to(equal(valH160))
+                    }
+                }
             }
         }
     }

--- a/Tests/PrimitiveTypesTests/H256Tests.swift
+++ b/Tests/PrimitiveTypesTests/H256Tests.swift
@@ -105,6 +105,38 @@ final class H256Spec: QuickSpec {
                         expect(val.toH160()).to(equal(valH160))
                     }
                 }
+
+                context("when hashing H256") {
+                    it("produces the same hash for equal values") {
+                        let bytes = [UInt8](repeating: 0xAB, count: 32)
+                        let h1 = H256(from: bytes)
+                        let h2 = H256(from: bytes)
+
+                        expect(h1.hashValue).to(equal(h2.hashValue))
+                    }
+
+                    it("produces different hash for different values") {
+                        let h1 = H256(from: [UInt8](repeating: 0x00, count: 32))
+                        let h2 = H256(from: [UInt8](repeating: 0x01, count: 32))
+
+                        expect(h1.hashValue).toNot(equal(h2.hashValue))
+                    }
+
+                    it("can be used in a Set") {
+                        let h1 = H256(from: [UInt8](repeating: 0x01, count: 32))
+                        let h2 = H256(from: [UInt8](repeating: 0x02, count: 32))
+                        let h3 = H256(from: [UInt8](repeating: 0x01, count: 32)) // same as h1
+
+                        var set: Set<H256> = []
+                        set.insert(h1)
+                        set.insert(h2)
+                        set.insert(h3)
+
+                        expect(set.count).to(equal(2))
+                        expect(set.contains(h1)).to(beTrue())
+                        expect(set.contains(h2)).to(beTrue())
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

➡️ Added `BALANCE` opcode logic
➡️ Added conversion for `PrimitiveTypes`: `H256` to `H160`
➡️ Added `ExecutionState` logic: warm and cold access for addresses
➡️ Extended `Machine` logic with `Handler` with `beforeOpcodeExecution`
➡️ Extended `Gas` logic for warm and cold
➡️ Refactored tests for Gas, added new tests for `Balance` opcode
➡️ Added Hashes to `H160` and `H256`. Extended tests.